### PR TITLE
Add option to disable notification sounds

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    cadre (1.0.4)
+    cadre (1.1.0)
       thor (>= 0.14, < 1.0)
       tilt (> 1.0)
       valise (~> 1.2)
@@ -52,7 +52,7 @@ GEM
     simplecov-json (0.2)
       json
       simplecov
-    thor (0.19.1)
+    thor (0.19.4)
     tilt (2.0.2)
     valise (1.2.0)
 
@@ -66,4 +66,4 @@ DEPENDENCIES
   rspec
 
 BUNDLED WITH
-   1.10.6
+   1.15.0

--- a/cadre.gemspec
+++ b/cadre.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |spec|
   spec.name		= "cadre"
    #{MAJOR: incompatible}.{MINOR added feature}.{PATCH bugfix}-{LABEL}
-  spec.version		= "1.0.4"
+  spec.version		= "1.1.0"
   author_list = {
     "Judson Lester" => 'nyarly@gmail.com'
   }

--- a/default_files/config.yaml
+++ b/default_files/config.yaml
@@ -1,5 +1,6 @@
 ---
 verbose: true
+sound: true
 quickfix:
   output_path: errors.err
   backtrace_pattern: '.*\.rb'

--- a/lib/cadre/config.rb
+++ b/lib/cadre/config.rb
@@ -34,6 +34,11 @@ module Cadre
     end
     alias quiet? quiet
 
+    def sound
+      !!value_or_fail("sound")
+    end
+    alias sound? sound
+
     def backtrace_pattern
       Regexp.new(value_or_fail('backtrace_pattern'))
     end

--- a/lib/cadre/libnotify/notifier.rb
+++ b/lib/cadre/libnotify/notifier.rb
@@ -1,9 +1,14 @@
 require 'cadre/valise'
+require 'cadre/config'
 
 module Cadre
   module Libnotify
     class Notifier < ::Cadre::Notifier
       register :libnotify
+
+      def sound_enabled?
+        @sound_enabled ||= Config.new(Valise, "libnotify").sound?
+      end
 
       def self.available?
         return availables["notify-send"]
@@ -13,10 +18,13 @@ module Cadre
         cmd = "notify-send #{options} \"#@summary\" \"#@message\""
         %x[#{cmd}]
 
-        if available?("paplay")
-          %x[paplay #{Valise.find(["sounds", sound]).full_path}] if String === sound
-        elsif available?("aplay")
-          %x[aplay #{Valise.find(["sounds", sound]).full_path}] if String === sound
+        if sound_enabled? && String === sound
+          filename = Valise.find(["sounds", sound]).full_path
+          if available?("paplay")
+            %x[paplay #{filename}]
+          elsif available?("aplay")
+            %x[aplay #{filename}]
+          end
         end
       end
 


### PR DESCRIPTION
Add the boolean option `sound` to `config.yaml` to control whether a sound
is played when libnotify generates a notification.

Update the minor version number to indicate addition of minor new functionality.